### PR TITLE
Migrate the underlying data store to a sorted set

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --require spec_helper
 --color
+--format documentation
 --backtrace

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,6 @@ Metrics/AbcSize:
 # Rely on AbcSize
 MethodLength:
   Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,12 @@ Metrics/AbcSize:
 # Rely on AbcSize
 MethodLength:
   Enabled: false
+
+require: rubocop-rspec
+
+RSpec/NestedGroups:
+  Enabled: false
+
+# Too many implicit subjects
+RSpec/NamedSubject:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Metrics/AbcSize:
 MethodLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
+
 require: rubocop-rspec
 
 RSpec/NestedGroups:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,3 @@ Metrics/AbcSize:
 # Rely on AbcSize
 MethodLength:
   Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false

--- a/lib/lita-stacker.rb
+++ b/lib/lita-stacker.rb
@@ -7,3 +7,4 @@ Lita.load_locales Dir[File.expand_path(
 )]
 
 require 'lita/handlers/stacker'
+require 'lita/handlers/stacker/upgrade/sorted_sets'

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -141,7 +141,7 @@ module Lita
       end
 
       def add_collision(response, user_to_add, score, room)
-        predecessors = redis.zrevrangebyscore(room, "(#{score}", 0)
+        predecessors = redis.zrangebyscore(room, 0, "(#{score}")
         type = predecessors.empty? ? 'first' : 'after'
         response.reply(t("add.collision.#{type}", user: "@#{user_to_add}", after: after_list(predecessors)))
       end

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -19,6 +19,9 @@ module Lita
               t('remove.help.done.command') => t('remove.help.done.description'),
               t('remove.help.drop.command') => t('remove.help.drop.description')
             })
+      route(/^restack(\s+\@\p{Word}+\s*)?$/, :lifo_requeue, help: {
+              t('remove.help.restack.command') => t('remove.help.restack.description')
+            })
       route(/^stacks? (show|list)/, :lifo_peek, help: {
               t('peek.help.show.singular.command') => t('peek.help.show.singular.description'),
               t('peek.help.show.plural.command') => t('peek.help.show.plural.description'),
@@ -102,6 +105,11 @@ module Lita
         else
           response.reply(t('remove.complete.other', user: to_remove))
         end
+      end
+
+      def lifo_requeue(response)
+        lifo_remove(response)
+        lifo_add(response)
       end
 
       def lifo_clear(response)

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/array/conversions' # Array.to_sentence, for i18
 module Lita
   module Handlers
     class Stacker < Handler
-      VERSION = '1.0.0'
+      VERSION = '0.3.0'
 
       config :timeout, type: Integer, default: 8 * 60 * 60 # 8.hours
 

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -32,8 +32,66 @@ module Lita
         return if incompatible?(response)
 
         user_to_add = pick_subject(response)
+
+        unless user_to_add
+          response.reply(t('add.not_found', user: "@#{pick_subject_name(response)}"))
+          return
+        end
+
+        result = perform_add(response.message.source.room, user_to_add)
+
+        if result.empty?
+          response.reply(t('add.first', user: subject_name(user_to_add)))
+        else
+          response.reply(t('add.after', user: subject_name(user_to_add), after: after_list(result)))
+        end
+      end
+
+      def lifo_peek(response)
+        return if incompatible?(response)
+
         room = response.message.source.room
 
+        clean_stack(room)
+        contents = redis.zrangebyscore(room, '-inf', '+inf')
+
+        if contents.empty?
+          response.reply(t('peek.empty'))
+          return
+        end
+
+        text_list = contents.each_with_index.map { |item, idx| "#{idx + 1}. #{subject_name(item)}" }.join("\n")
+        response.reply(t('peek.list', newline_separated_list: text_list))
+      end
+
+      def lifo_remove(response)
+        return if incompatible?(response)
+
+        to_remove = pick_subject(response)
+
+        unless to_remove
+          result.reply(t('remove.not_found', user: "@#{pick_subject_name(response)}"))
+          return
+        end
+
+        next_user = perform_remove(response.message.source.room, to_remove)
+
+        if next_user
+          response.reply(t('remove.complete.first', user: subject_name(to_remove), next_user: subject_name(next_user)))
+        else
+          response.reply(t('remove.complete.other', user: subject_name(to_remove)))
+        end
+      end
+
+      def lifo_clear(response)
+        return if incompatible?(response)
+        redis.del(response.message.source.room)
+        response.reply(t('clear.complete', user: "@#{response.user.mention_name}"))
+      end
+
+      private
+
+      def perform_add(room, user)
         clean_stack(room)
 
         script = <<~LUA
@@ -42,35 +100,13 @@ module Lita
           return predecessors
         LUA
 
-        result = redis.eval(script, [room], [user_to_add, Time.now.to_f])
-        result.delete(user_to_add)
-
-        if result.empty?
-          response.reply(t('add.first', user: "@#{user_to_add}"))
-        else
-          response.reply(t('add.after', user: "@#{user_to_add}", after: after_list(result)))
-        end
+        result = redis.eval(script, [room], [user.id, Time.now.to_f])
+        result.delete(user.id)
+        result
       end
 
-      def lifo_peek(response)
-        return if incompatible?(response)
-
-        clean_stack(response.message.source.room)
-        contents = redis.zrangebyscore(response.message.source.room, '-inf', '+inf')
-
-        if contents.empty?
-          response.reply(t('peek.empty'))
-          return
-        end
-
-        text_list = contents.each_with_index.map { |item, idx| "#{idx + 1}. @#{item}" }.join("\n")
-        response.reply(t('peek.list', newline_separated_list: text_list))
-      end
-
-      def lifo_remove(response)
-        return if incompatible?(response)
-
-        to_remove = pick_subject(response)
+      def perform_remove(room, user)
+        clean_stack(room)
 
         # Simulate ZPOPMIN, which is only available starting in Redis 5.
         script = <<~LUA
@@ -84,32 +120,29 @@ module Lita
           return redis.call('zrange', KEYS[1], 0, 0)[1]
         LUA
 
-        clean_stack(response.message.source.room)
-        next_user = redis.eval(script, [response.message.source.room], [to_remove])
+        redis.eval(script, [room], [user.id])
+      end
 
-        to_remove = "@#{to_remove}"
+      def subject_name(user)
+        mention = if user.respond_to?(:mention_name)
+                    user.mention_name || user.name
+                  else
+                    Lita::User.find_by_id(user)&.mention_name
+                  end
 
-        if next_user
-          response.reply(t('remove.complete.first', user: to_remove, next_user: "@#{next_user}"))
+        if mention
+          mention.sub(/^@?/, '@')
         else
-          response.reply(t('remove.complete.other', user: to_remove))
+          "<#{user}>"
         end
       end
-
-      def lifo_clear(response)
-        return if incompatible?(response)
-        redis.del(response.message.source.room)
-        response.reply(t('clear.complete', user: "@#{response.user.mention_name}"))
-      end
-
-      private
 
       def after_list(list)
         # This require cannot be at the top level, or the gemspec cannot be
         # loaded without it already being present, which prevents the
         # dependency being asserted.
         require 'active_support/core_ext/array/conversions'
-        list.map { |x| "@#{x}" }.to_sentence
+        list.map { |u| subject_name(u) }.to_sentence
       end
 
       def clean_stack(stack)
@@ -121,6 +154,11 @@ module Lita
       end
 
       def pick_subject(response)
+        subject = pick_subject_name(response)
+        Lita::User.find_by_mention_name(subject) || Lita::User.find_by_name(subject)
+      end
+
+      def pick_subject_name(response)
         subject = response.user.mention_name.tr('@', '')
         if response.message.args[0]
           arg = response.message.args[0].dup

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/array/conversions' # Array.to_sentence, for i18n
-
 module Lita
   module Handlers
     class Stacker < Handler
@@ -107,6 +105,10 @@ module Lita
       private
 
       def after_list(list)
+        # This require cannot be at the top level, or the gemspec cannot be
+        # loaded without it already being present, which prevents the
+        # dependency being asserted.
+        require 'active_support/core_ext/array/conversions'
         list.map { |x| "@#{x}" }.to_sentence
       end
 

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -19,9 +19,6 @@ module Lita
               t('remove.help.done.command') => t('remove.help.done.description'),
               t('remove.help.drop.command') => t('remove.help.drop.description')
             })
-      route(/^restack(\s+\@\p{Word}+\s*)?$/, :lifo_requeue, help: {
-              t('remove.help.restack.command') => t('remove.help.restack.description')
-            })
       route(/^stacks? (show|list)/, :lifo_peek, help: {
               t('peek.help.show.singular.command') => t('peek.help.show.singular.description'),
               t('peek.help.show.plural.command') => t('peek.help.show.plural.description'),
@@ -88,11 +85,6 @@ module Lita
         else
           response.reply(t('remove.complete.other', user: to_remove))
         end
-      end
-
-      def lifo_requeue(response)
-        lifo_remove(response)
-        lifo_add(response)
       end
 
       def lifo_clear(response)

--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -19,9 +19,11 @@ module Lita
               t('remove.help.done.command') => t('remove.help.done.description'),
               t('remove.help.drop.command') => t('remove.help.drop.description')
             })
-      route(/^stacks? show/, :lifo_peek, help: {
-              t('peek.help.singular.command') => t('peek.help.singular.description'),
-              t('peek.help.plural.command') => t('peek.help.plural.description')
+      route(/^stacks? (show|list)/, :lifo_peek, help: {
+              t('peek.help.show.singular.command') => t('peek.help.show.singular.description'),
+              t('peek.help.show.plural.command') => t('peek.help.show.plural.description'),
+              t('peek.help.list.singular.command') => t('peek.help.list.singular.description'),
+              t('peek.help.list.plural.command') => t('peek.help.list.plural.description')
             })
       route(/^stacks? clear/, :lifo_clear, help: {
               t('clear.help.singular.command') => t('clear.help.singular.description'),

--- a/lib/lita/handlers/stacker/upgrade/sorted_sets.rb
+++ b/lib/lita/handlers/stacker/upgrade/sorted_sets.rb
@@ -42,7 +42,10 @@ module Lita
           def list_scores(list)
             # Add an offset so the scores are not identical
             offset = config.offset
-            list.each_with_index.map { |name, i| [Time.now.to_f - config.timeout + offset * i, name] }
+            list.each_with_index.each_with_object([]) do |(name, i), l|
+              user = Lita::User.find_by_mention_name(name) || Lita::User.find_by_name(name)
+              l.push([Time.now.to_f - config.timeout + offset * i, user.id]) if user
+            end
           end
         end
       end

--- a/lib/lita/handlers/stacker/upgrade/sorted_sets.rb
+++ b/lib/lita/handlers/stacker/upgrade/sorted_sets.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Lita
+  module Handlers
+    class Stacker
+      module Upgrade
+        class SortedSets
+          extend Lita::Handler::EventRouter
+
+          namespace 'stacker'
+          on :loaded, :update_store
+
+          # To prevent disrupting stacks in progress, set a window smaller than the default timeout
+          # for them to be valid.
+          config :timeout, type: Integer, default: 2 * 60 * 60 # 2.hours
+          config :offset, type: Float, default: 0.1
+
+          SUPPORT_KEY = 'support:zsets'
+
+          def update_store(_payload)
+            return if redis.exists(SUPPORT_KEY)
+
+            redis.keys.each do |key|
+              next unless redis.type(key) == 'list'
+              list = redis.lrange(key, 0, -1)
+              list = list.uniq
+
+              redis.del(key)
+
+              # Add an offset so the scores are not identical
+              offset = config.offset
+              values = list.each_with_index.map { |name, i| [Time.now.to_f - config.timeout + offset * i, name] }
+              redis.zadd(key, values)
+            end
+
+            redis.incr(SUPPORT_KEY)
+          end
+        end
+      end
+    end
+  end
+end
+
+Lita.register_handler(Lita::Handlers::Stacker::Upgrade::SortedSets)

--- a/lita-stacker.gemspec
+++ b/lita-stacker.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'activesupport', '~> 5.2'
   spec.add_runtime_dependency 'lita', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/lita-stacker.gemspec
+++ b/lita-stacker.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.7.0'
   spec.add_development_dependency 'rubocop', '>= 0.58.1'
+  spec.add_development_dependency 'rubocop-rspec', '>= 1.28.0'
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,9 +4,9 @@ en:
       stacker:
         add:
           collision:
-            self: You are already in the stack list!
-            other: '%{user} is already in the stack list!'
-          first: '%{user}, you have the floor!'
+            first: '%{user} already has the floor. Please use `unstack` when you are done.'
+            after: '%{user} is already in the stack list, behind %{after}'
+          first: '%{user}, you have the floor! Please use `unstack` when you are done.'
           after: '%{user} has been added after %{after}.'
           help:
             simple:
@@ -20,7 +20,7 @@ en:
               description: add @user to the stack list
         remove:
           complete:
-            first: '%{user} is gone from the stack. %{next_user} is up next.'
+            first: '%{user} is gone from the stack. %{next_user} is up next. Please use `unstack` when you are done.'
             other: '%{user} is gone from the stack.'
           help:
             unstack:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,9 +3,6 @@ en:
     handlers:
       stacker:
         add:
-          collision:
-            first: '%{user} already has the floor. Please use `unstack` when you are done.'
-            after: '%{user} is already in the stack list, behind %{after}'
           first: '%{user}, you have the floor! Please use `unstack` when you are done.'
           after: '%{user} has been added after %{after}.'
           help:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,8 +4,8 @@ en:
       stacker:
         add:
           collision:
-            first: '%{user} already has the floor. Please use `unstack` when you are done.'
-            after: '%{user} is already in the stack list, behind %{after}'
+            first: '%{user} already has the floor. Please use `unstack` when you are done, or `restack` to change your position to the bottom.'
+            after: '%{user} is already in the stack list, behind %{after}. Please use `restack` if you wish to change your position to the bottom.'
           first: '%{user}, you have the floor! Please use `unstack` when you are done.'
           after: '%{user} has been added after %{after}.'
           help:
@@ -32,6 +32,10 @@ en:
             drop:
               command: 'stack drop [@user]'
               description: 'remove yourself (or @user) from the stack list'
+        readd:
+          help:
+            command: 'restack [@user]'
+            description: 'remove and readd yourself (or @user) to the stack list'
         peek:
           empty: The stack is empty!
           list: "Stacks:\n%{newline_separated_list}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -36,12 +36,20 @@ en:
           empty: The stack is empty!
           list: "Stacks:\n%{newline_separated_list}"
           help:
-            singular:
-              command: stack show
-              description: show the list of stacks
-            plural:
-              command: stacks show
-              description: show the list of stacks
+            show:
+              singular:
+                command: stack show
+                description: show the list of stacks
+              plural:
+                command: stacks show
+                description: show the list of stacks
+            list:
+              singular:
+                command: stack list
+                description: show the list of stacks
+              plural:
+                command: stacks list
+                description: show the list of stacks
         clear:
           complete: 'Stacks cleared by %{user}'
           help:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,8 +4,8 @@ en:
       stacker:
         add:
           collision:
-            first: '%{user} already has the floor. Please use `unstack` when you are done, or `restack` to change your position to the bottom.'
-            after: '%{user} is already in the stack list, behind %{after}. Please use `restack` if you wish to change your position to the bottom.'
+            first: '%{user} already has the floor. Please use `unstack` when you are done.'
+            after: '%{user} is already in the stack list, behind %{after}'
           first: '%{user}, you have the floor! Please use `unstack` when you are done.'
           after: '%{user} has been added after %{after}.'
           help:
@@ -32,10 +32,6 @@ en:
             drop:
               command: 'stack drop [@user]'
               description: 'remove yourself (or @user) from the stack list'
-        readd:
-          help:
-            command: 'restack [@user]'
-            description: 'remove and readd yourself (or @user) to the stack list'
         peek:
           empty: The stack is empty!
           list: "Stacks:\n%{newline_separated_list}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,6 +3,7 @@ en:
     handlers:
       stacker:
         add:
+          not_found: Cannot find user named %{user}
           first: '%{user}, you have the floor! Please use `unstack` when you are done.'
           after: '%{user} has been added after %{after}.'
           help:
@@ -16,6 +17,7 @@ en:
               command: 'stack @user'
               description: add @user to the stack list
         remove:
+          not_found: Cannot find user named %{user}
           complete:
             first: '%{user} is gone from the stack. %{next_user} is up next. Please use `unstack` when you are done.'
             other: '%{user} is gone from the stack.'

--- a/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
+++ b/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Lita::Handlers::Stacker::Upgrade::SortedSets, lita_handler: true 
       expect(subject.redis.zrangebyscore(:channel, '-inf', '+inf')).to eq lists[:channel]
     end
 
-    it 'removes duplicate stacks, in the correct order' do
+    it 'removes duplicate stacks, maintaining the correct order' do
       subject.update_store(payload)
       expect(subject.redis.zrangebyscore(:channel_with_duplicates, '-inf', '+inf')).to eq lists[:channel]
     end

--- a/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
+++ b/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
@@ -13,14 +13,22 @@ RSpec.describe Lita::Handlers::Stacker::Upgrade::SortedSets, lita_handler: true 
   end
 
   context 'when there are stores to upgrade' do
+    let(:arthur) { Lita::User.create(42, name: 'Arthur', mention_name: 'arthur') }
+    let(:ford) { Lita::User.create(23, name: 'Ford', mention_name: 'ford') }
+    let(:trillian) { Lita::User.create(456, name: 'Tricia MacMillian', mention_name: 'trillian') }
+    let(:zaphod) { Lita::User.create(123, name: 'Zaphod', mention_name: 'zaphod') }
+
     let(:lists) do
       {
         channel: %w[zaphod trillian ford arthur],
-        channel_with_duplicates: %w[zaphod trillian ford zaphod arthur zaphod ford]
+        channel_with_duplicates: %w[zaphod trillian ford marvin zaphod arthur zaphod marvin ford marvin]
       }
     end
 
+    let(:users) { [zaphod, trillian, ford, arthur] }
+
     before do
+      users
       lists.each { |channel, names| subject.redis.rpush(channel, names) }
     end
 
@@ -31,12 +39,12 @@ RSpec.describe Lita::Handlers::Stacker::Upgrade::SortedSets, lita_handler: true 
 
     it 'maintains the same order for the set' do
       subject.update_store(payload)
-      expect(subject.redis.zrangebyscore(:channel, '-inf', '+inf')).to eq lists[:channel]
+      expect(subject.redis.zrangebyscore(:channel, '-inf', '+inf')).to eq users.map(&:id)
     end
 
-    it 'removes duplicate stacks, maintaining the correct order' do
+    it 'removes duplicate and invalid stacks, maintaining the correct order' do
       subject.update_store(payload)
-      expect(subject.redis.zrangebyscore(:channel_with_duplicates, '-inf', '+inf')).to eq lists[:channel]
+      expect(subject.redis.zrangebyscore(:channel_with_duplicates, '-inf', '+inf')).to eq users.map(&:id)
     end
   end
 end

--- a/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
+++ b/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
@@ -2,13 +2,14 @@
 
 RSpec.describe Lita::Handlers::Stacker::Upgrade::SortedSets, lita_handler: true do
   before { subject.redis.del(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY) }
+
   after { subject.redis.del(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY) }
 
   let(:payload) { {} }
 
   it 'increments the support flag' do
     subject.update_store(payload)
-    expect(subject.redis.exists(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY))
+    expect(subject.redis.exists(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY)).to be true
   end
 
   context 'when there are stores to upgrade' do

--- a/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
+++ b/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Lita::Handlers::Stacker::Upgrade::SortedSets, lita_handler: true do
+  before { subject.redis.del(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY) }
+  after { subject.redis.del(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY) }
+
+  let(:payload) { {} }
+
+  it 'increments the support flag' do
+    subject.update_store(payload)
+    expect(subject.redis.exists(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY))
+  end
+
+  context 'when there are stores to upgrade' do
+    let(:lists) do
+      {
+        channel: %w[zaphod trillian ford arthur],
+        channel_with_duplicates: %w[zaphod trillian ford zaphod arthur zaphod ford]
+      }
+    end
+
+    before do
+      lists.each { |channel, names| subject.redis.rpush(channel, names) }
+    end
+
+    it 'changes the types to sorted sets' do
+      subject.update_store(payload)
+      lists.each { |channel, _names| expect(subject.redis.type(channel)).to eq 'zset' }
+    end
+
+    it 'maintains the same order for the set' do
+      subject.update_store(payload)
+      expect(subject.redis.zrangebyscore(:channel, '-inf', '+inf')).to eq lists[:channel]
+    end
+
+    it 'removes duplicate stacks, in the correct order' do
+      subject.update_store(payload)
+      expect(subject.redis.zrangebyscore(:channel_with_duplicates, '-inf', '+inf')).to eq lists[:channel]
+    end
+  end
+end

--- a/spec/lita/handlers/stacker_spec.rb
+++ b/spec/lita/handlers/stacker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
     end
   end
 
-  shared_context 'in a room' do
+  shared_context 'in a room' do # rubocop:disable RSpec/ContextWording # clumsy otherwise
     let(:channel) { Lita::Room.create_or_update('#public_channel') }
     let(:command_options) { { from: channel } }
   end
@@ -186,9 +186,9 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
     context 'when the message is in a room' do
       include_context 'in a room'
 
-      it_behaves_like 'it clears old stacks'
-
       let(:other_user) { Lita::User.create(123, name: 'Zaphod', mention_name: '@beeblebrox') }
+
+      it_behaves_like 'it clears old stacks'
 
       before do
         send_command('stack', command_options)

--- a/spec/lita/handlers/stacker_spec.rb
+++ b/spec/lita/handlers/stacker_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
             send_command 'stack show', command_options
             expect(replies.last).to include(target_user.mention_name)
           end
+
+          context 'when the stack has more than 2 entries' do
+            let(:existing_stack) { %w{Trillian Ford Arthur Marvin} }
+
+            it 'announces the whole list' do
+              expect(replies.last).to match Regexp.new existing_stack.join('.*')
+            end
+          end
         end
 
         context 'when the user is already in the stack' do

--- a/spec/lita/handlers/stacker_spec.rb
+++ b/spec/lita/handlers/stacker_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
   it { is_expected.to route_command('unstack @user').to(:lifo_remove) }
   it { is_expected.to route_command('stack drop').to(:lifo_remove) }
   it { is_expected.to route_command('stack done').to(:lifo_remove) }
-  it { is_expected.to route_command('restack').to(:lifo_requeue) }
-  it { is_expected.to route_command('restack @user').to(:lifo_requeue) }
   it { is_expected.to route_command('stack show').to(:lifo_peek) }
   it { is_expected.to route_command('stacks show').to(:lifo_peek) }
   it { is_expected.to route_command('stack clear').to(:lifo_clear) }
@@ -199,76 +197,6 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
         it 'does not announce the first user' do
           send_command("unstack #{other_user.mention_name}", command_options)
           expect(replies.last).not_to include user.mention_name
-        end
-      end
-    end
-  end
-
-  describe '#lifo_requeue' do
-    let(:command) { 'restack' }
-
-    it_behaves_like 'a private chat'
-
-    context 'when the message is in a room' do
-      include_context 'in a room'
-
-      it_behaves_like 'it clears old stacks'
-
-      shared_examples 'it adds the user at the bottom' do
-        it 'adds the user at the bottom' do
-          send_command(command, command_options)
-          send_command('stack show', command_options)
-          expect(replies.last).to end_with user.mention_name
-        end
-
-        it 'does not duplicate the stack' do
-          send_command(command, command_options)
-          send_command('stack show', command_options)
-          expect(replies.last.scan(/#{user.mention_name}/).count).to eq 1
-        end
-      end
-
-      context 'when the user is not in the stack' do
-        it_behaves_like 'it adds the user at the bottom'
-      end
-
-      context 'when the user is in the stack' do
-        before do
-          send_command('stack @Trillian', command_options)
-          send_command('stack', command_options)
-        end
-
-        context 'when they are first' do
-          before { send_command('unstack @Trillian', command_options) }
-
-          context 'when there is someone else in the stack' do
-            before { send_command('stack @Trillian', command_options) }
-
-            it_behaves_like 'it adds the user at the bottom'
-
-            it 'announces the next user' do
-              send_command(command, command_options)
-              expect(replies[-2]).to include 'Trillian'
-            end
-          end
-
-          context 'when there is not somone else in the stack' do
-            it_behaves_like 'it adds the user at the bottom'
-
-            it 'does not announce the next user' do
-              send_command(command, command_options)
-              expect(replies[-2]).not_to include 'floor'
-            end
-          end
-        end
-
-        context 'when they are not first' do
-          it_behaves_like 'it adds the user at the bottom'
-
-          it 'does not announce the next user' do
-            send_command(command, command_options)
-            expect(replies[-2]).not_to include 'floor'
-          end
         end
       end
     end

--- a/spec/lita/handlers/stacker_spec.rb
+++ b/spec/lita/handlers/stacker_spec.rb
@@ -89,12 +89,21 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
           end
 
           it 'informs the user' do
-            expect(replies.last).to match(/already.*behind @Trillian/)
+            expect(replies.last).to match(/after @Trillian/)
           end
 
-          it 'does not add to the stack' do
+          it 'does not include the user in the list of predecessors' do
+            expect(replies.last).not_to match(/after.*#{target_user.mention_name}/)
+          end
+
+          it 'does not add an additional the stack' do
             send_command 'stack show', command_options
             expect(replies.last.scan(/^\d+\.\s*@?#{target_user.mention_name}/).count).to eq 1
+          end
+
+          it 'moves them to the bottom' do
+            send_command 'stack show', command_options
+            expect(replies.last).to end_with target_user.mention_name
           end
         end
       end

--- a/spec/lita/handlers/stacker_spec.rb
+++ b/spec/lita/handlers/stacker_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Lita::Handlers::Stacker, lita_handler: true do
 
           it 'does not add to the stack' do
             send_command 'stack show', command_options
-            expect(replies.last.split(/\n/).grep(/\d+\. @?#{target_user.mention_name}/).size).to eq 1
+            expect(replies.last.scan(/^\d+\.\s*@?#{target_user.mention_name}/).count).to eq 1
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,7 +108,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  config.before(:example) do
+  config.before do
     Redis.new.flushdb
   end
 end


### PR DESCRIPTION
Sorted sets are a more fully supported data structure than lists in Redis, and we can use the score of the sorted set to represent when they were added, and age them out so we don’t end up with a channel with a stack of 300+ entries.

Also add a `restack` command to bump yourself to the bottom. This was favored over silently doing this when a user already in the list stacks again, since that may lead to someone losing their place.

The collision error messages (as well as the “You have the floor” message) have been improved to remind folks to unstack when they are done, or restack if they wish to be added to the bottom.

