### PR TITLE
[ST-1975] Upgrade lita

### DIFF
--- a/lib/lita/handlers/stacker.rb
+++ b/lib/lita/handlers/stacker.rb
@@ -3,8 +3,6 @@
 module Lita
   module Handlers
     class Stacker < Handler
-      VERSION = '0.4.0'
-
       config :timeout, type: Integer, default: 8 * 60 * 60 # 8.hours
 
       route(/^stack(\s+(on.*|\@\p{Word}+\s*))?$/, :lifo_add, help: {

--- a/lib/lita/handlers/stacker/upgrade/sorted_sets.rb
+++ b/lib/lita/handlers/stacker/upgrade/sorted_sets.rb
@@ -18,7 +18,7 @@ module Lita
           SUPPORT_KEY = 'support:zsets'
 
           def update_store(_payload)
-            return if redis.exists(SUPPORT_KEY)
+            return if redis.exists?(SUPPORT_KEY)
 
             redis.keys.each do |key|
               update_key(key)

--- a/lita-stacker.gemspec
+++ b/lita-stacker.gemspec
@@ -1,12 +1,6 @@
-# frozen_string_literal: true
-
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'lita-stacker'
-
 Gem::Specification.new do |spec|
   spec.name          = 'lita-stacker'
-  spec.version       = Lita::Handlers::Stacker::VERSION
+  spec.version       = '0.4.0'
   spec.authors       = ['Kyle VanderBeek']
   spec.email         = ['kyle@change.org']
   spec.summary       = 'A Lita handler for keeping order of people who wish to speak.'
@@ -21,12 +15,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activesupport', '~> 5.2'
-  spec.add_runtime_dependency 'lita', '~> 4.0'
+  spec.add_runtime_dependency 'lita', '~> 4.8'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '>= 3.7.0'
-  spec.add_development_dependency 'rubocop', '>= 0.58.1'
-  spec.add_development_dependency 'rubocop-rspec', '>= 1.28.0'
+  spec.add_development_dependency 'rspec', '~> 3.11'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop-rspec'
 end

--- a/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
+++ b/spec/lita/handlers/stacker/upgrade/sorted_sets_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Lita::Handlers::Stacker::Upgrade::SortedSets, lita_handler: true 
 
   it 'increments the support flag' do
     subject.update_store(payload)
-    expect(subject.redis.exists(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY)).to be true
+    expect(subject.redis.exists?(Lita::Handlers::Stacker::Upgrade::SortedSets::SUPPORT_KEY)).to be true
   end
 
   context 'when there are stores to upgrade' do


### PR DESCRIPTION
@change/pack-starters @change/squad-starter-growth 

The version of lita was updated, with this update we also changed the bundler version and the version that redis uses 

The main change on redis was that the `exists` function now returns an integer, so we changed for `exists?`